### PR TITLE
Fix typo in instructions for TodoItem.tsx

### DIFF
--- a/getting-started/README.md
+++ b/getting-started/README.md
@@ -85,7 +85,7 @@ Our component needs inputs! Right now all it needs is a `Todo` to display. All R
 
 ```tsx
 import React, {FC} from 'react'
-import Todo from './TodoTypes'
+import {Todo} from './TodoTypes'
 
 interface TodoItemProps {
     todo: Todo;


### PR DESCRIPTION
`import Todo from './TodoTypes'` causes a compilation error with the suggestion to add curly braces around `Todo`. I checked in the `hooks` directory and saw that `TodoItem.tsx` included those curlies and figured this was a typo in the readme.